### PR TITLE
🚨 Add Missing GitHub Skills Activity (Urgent)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🚨 Urgent: Add Missing GitHub Skills Activity

This PR addresses the urgent issue raised in #6 where the GitHub Skills activity announced by the principal is missing from the school activities signup page.

### Changes Made
- ✅ Added "GitHub Skills" activity to the activities database
- ✅ Included description mentioning GitHub Certifications program and college applications
- ✅ Scheduled for Mondays 3:30-4:30 PM (avoids conflicts with existing activities)  
- ✅ Set participant limit to 25 students
- ✅ Started with empty participants list for new registrations

### Why This is Urgent
- 📅 **Time-sensitive**: Registration deadline is end of this week
- 🎓 **Student impact**: Many students are eager to join for college applications
- 📢 **Principal announcement**: This was officially announced in the school assembly
- 🤝 **Partnership**: Part of new GitHub partnership for practical coding skills

### Testing
The new activity will appear in the activities list and students can now register for the GitHub Skills program as expected.

Fixes #6

### Preview
The GitHub Skills activity will now show:
- **Description**: "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications."
- **Schedule**: "Mondays, 3:30 PM - 4:30 PM"  
- **Capacity**: 25 students
- **Current participants**: None (ready for new signups)